### PR TITLE
outputs warnings for unsupported types (closes #4)

### DIFF
--- a/cmd/protonize.go
+++ b/cmd/protonize.go
@@ -364,8 +364,16 @@ func parseTerraformSource(name, srcDir string) ([]schemaVariable, outputData) {
 			sv.Default = nil
 		}
 
-		//unsupported types (for now)
-		if strings.HasPrefix(sv.Type, "object(") || strings.HasPrefix(sv.Type, "map(") {
+		//output warning for unsupported types
+		if strings.HasPrefix(sv.Type, "object(") ||
+			strings.HasPrefix(sv.Type, "any") ||
+			strings.HasPrefix(sv.Type, "map(") ||
+			strings.HasPrefix(sv.Type, "set(") {
+
+			fmt.Println("WARNING: skipping unsupported input variable:")
+			fmt.Println(v.Name)
+			fmt.Println(v.Type)
+			fmt.Println()
 			continue
 		}
 


### PR DESCRIPTION
*Issue #, if available:* #4

*Description of changes:* outputs warnings for unsupported types

example:
```
WARNING: skipping unsupported input variable:
tags
map(string)

WARNING: skipping unsupported input variable:
cors_rules
set(object({
    allowed_headers = list(string),
    allowed_methods = list(string),
    allowed_origins = list(string),
    expose_headers  = list(string),
    max_age_seconds = number
  }))

WARNING: skipping unsupported input variable:
replication_configuration_set
set(object({
    role = string,
    rules = set(object({
      id                                           = string
      priority                                     = number
      status                                       = string
      destination_account_id                       = string
      destination_bucket                           = string
      destination_access_control_translation_owner = string
    }))
  }))

WARNING: skipping unsupported input variable:
lifecycle_rules
any

WARNING: skipping unsupported input variable:
replication_configuration_shortcut
object({
    destination_account_id = string
    destination_bucket     = string
  })

WARNING: skipping unsupported input variable:
replication_source
object({
    account_id = string
    role       = string
  })

template source outputted to /code/proton/templates/s3
done
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
