### PR TITLE
Source reserved vars from metadata (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,28 @@ https://us-east-1.console.aws.amazon.com/proton/home?region=us-east-1#/templates
 Note that this can also be done inline with the `protonize --publish` command.
 
 
+### Terraform variable mapping
+
+To avoid conflicts, if you have variables in your source templates with reserved names in Proton (i.e., `name` and `environment`), they will be removed as template input variables and instead be sourced from proton metadata.
+
+
+#### Environment templates
+
+If the source terraform module has an input variable named `name`, it will be supplied by the name of the proton environment rather than by template specific input.
+
+
+#### Service templates
+
+If the source terraform module has a variable named `name`, it will be set to the name of the service and the service instance with a `-` (dash) in between.  If the source terraform module has a variable named `environment`, it will be set to the service instance's environment name.
+
+For example, when creating a service named `sales-api` and a service instance named `dev` associated with a proton environment named `dev`, the Terraform module will get passed the following values:
+
+```hcl
+name = "sales-api-dev"
+environment = "dev"
+```
+
+
 ### Development
 
 #### Setup

--- a/cmd/templates/schema.env.yamltemplate
+++ b/cmd/templates/schema.env.yamltemplate
@@ -7,7 +7,7 @@ schema:
       type: object
       description: Environment input properties
       properties:
-      {{ range $v := . }}
+      {{ range $v := . }}{{ if ne $v.Name "name" }}
         {{ $v.Name }}:
           title: {{ $v.Name }}
           type: {{ $v.Type }}
@@ -16,4 +16,4 @@ schema:
           {{ end }}
           description: "{{ $v.Description }}"
           {{ if ne nil $v.Default }}default: {{ $v.Default }}{{ end }}
-      {{ end }}
+      {{ end }}{{ end }}

--- a/cmd/templates/schema.svc.yamltemplate
+++ b/cmd/templates/schema.svc.yamltemplate
@@ -7,7 +7,7 @@ schema:
       type: object
       description: Service input properties
       properties:
-      {{ range $v := . }}
+      {{ range $v := . }}{{ if and (ne $v.Name "name") (ne $v.Name "environment") }}
         {{ $v.Name }}:
           title: {{ $v.Name }}
           type: {{ $v.Type }}
@@ -16,4 +16,4 @@ schema:
           {{ end }}
           description: "{{ $v.Description }}"
           {{ if ne nil $v.Default }}default: {{ $v.Default }}{{ end }}
-      {{ end }}
+      {{ end }}{{ end }}

--- a/cmd/templates/terraform/main.env.tftemplate
+++ b/cmd/templates/terraform/main.env.tftemplate
@@ -23,6 +23,7 @@ module "{{ .ModuleName }}" {
   source = "./src"
 
 {{ range $v := .Variables }}
+  {{ if eq $v.Name "name" }}name = var.environment.name{{ else }}
   {{ $v.Name }} = var.environment.inputs.{{ $v.Name }}
-{{ end }}
+{{ end }}{{ end }}
 }

--- a/cmd/templates/terraform/main.svc.tftemplate
+++ b/cmd/templates/terraform/main.svc.tftemplate
@@ -25,6 +25,7 @@ module "{{ .ModuleName }}" {
   source = "./src"
 
 {{ range $v := .Variables }}
+  {{ if eq $v.Name "name" }}name = "${var.service.name}-${var.service_instance.name}"{{ else if eq $v.Name "environment" }}environment = var.environment.name{{ else }}
   {{ $v.Name }} = var.service_instance.inputs.{{ $v.Name }}
-{{ end }}
+{{ end }}{{ end }}
 }

--- a/cmd/templates/terraform/manifest.yamltemplate
+++ b/cmd/templates/terraform/manifest.yamltemplate
@@ -7,14 +7,14 @@ infrastructure:
           golang: 1.18 # not needed, but required by proton (for now)
         env:
           variables:
-            TF_VERSION: 1.3.9
+            TF_VERSION: 1.4.5
             AWS_REGION: us-east-1
             TF_STATE_BUCKET: {{ .TerraformS3StateBucket }}
 
         provision:
 
           # get proton metadata from input file
-          - export IN=$(cat proton-inputs.json)
+          - export IN=$(cat proton-inputs.json) && echo ${IN}
           - export PROTON_ENV=$(echo $IN | jq '.environment.name' -r)
 {{ if eq .TemplateType "service" }}
           - export PROTON_SVC=$(echo $IN | jq '.service.name' -r)
@@ -42,7 +42,7 @@ infrastructure:
         deprovision:
 
            # get proton metadata from input file
-          - export IN=$(cat proton-inputs.json)
+          - export IN=$(cat proton-inputs.json) && echo ${IN}
           - export PROTON_ENV=$(echo $IN | jq '.environment.name' -r)
 {{ if eq .TemplateType "service" }}
           - export PROTON_SVC=$(echo $IN | jq '.service.name' -r)

--- a/cmd/test/main.tf
+++ b/cmd/test/main.tf
@@ -3,6 +3,11 @@ variable "name" {
   type        = string
 }
 
+variable "environment" {
+  description = "Another environment name"
+  type        = string
+}
+
 variable "vpc_cidr" {
   description = "The CIDR range for the VPC"
   type        = string

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-config-inspect/tfconfig"
 )
 
 // handle errors
@@ -50,11 +54,37 @@ func debugFmt(format string, a ...interface{}) {
 }
 
 // SliceContains returns true if a slice contains a string
-func SliceContains(s *[]string, e string) bool {
+func SliceContains(s *[]string, e string, trim bool) bool {
 	for _, str := range *s {
+		if trim {
+			str = strings.TrimSpace(str)
+		}
 		if str == e {
 			return true
 		}
 	}
 	return false
+}
+
+// sorts a TF module's variables
+func sortTFVariables(module *tfconfig.Module) []tfconfig.Variable {
+	result := []tfconfig.Variable{}
+	for _, v := range module.Variables {
+		result = append(result, *v)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func sortTFOutputs(module *tfconfig.Module) []tfconfig.Output {
+	result := []tfconfig.Output{}
+	for _, v := range module.Outputs {
+		result = append(result, *v)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
 }


### PR DESCRIPTION
*Issue #, if available:* #3

*Description of changes:* For Terraform input, sources reserved variables (i.e., `name` and `environment`) from Proton metadata rather than template input.

For example, when creating a service named `sales-api` and a service instance named `dev` associated with a proton environment named `dev`, the Terraform module will get passed the following values:

```hcl
name = "sales-api-dev"
environment = "dev"
```

Also sorts input/output variables for more deterministic output and updates Terraform to `1.4.5`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
