### PR TITLE
handle quotes in variable descriptions (closes #8)

### DIFF
--- a/cmd/protonize.go
+++ b/cmd/protonize.go
@@ -341,11 +341,14 @@ func parseTerraformSource(name, srcDir string) ([]schemaVariable, outputData) {
 	for _, v := range inputVars {
 		debugFmt("%v (type: %v; default: %v) \n", v.Name, v.Type, v.Default)
 
+		//escape quotes in descriptions
+		desc := strings.Replace(v.Description, `"`, `\"`, -1)
+
 		sv := schemaVariable{
 			Name:        v.Name,
 			Title:       v.Name,
 			Type:        v.Type,
-			Description: v.Description,
+			Description: desc,
 			Default:     v.Default,
 			Required:    v.Required,
 		}

--- a/cmd/protonize_test.go
+++ b/cmd/protonize_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hack-pad/hackpadfs"
 	"github.com/hack-pad/hackpadfs/mem"
 	"github.com/jritsema/scaffolder"
+	"gopkg.in/yaml.v3"
 )
 
 func TestGenerateEnvironmentTemplate(t *testing.T) {
@@ -182,6 +183,21 @@ func internalTestGenerateTemplate(t *testing.T, templateType protonTemplateType,
 		if SliceContains(&pathsToCheck, path, false) {
 			findings++
 			t.Log("found", path)
+		}
+
+		//test that any generated yaml is valid
+		if strings.HasSuffix(path, "yaml") || strings.HasSuffix(path, "yml") {
+			t.Log("testing", path)
+			contents, err := hackpadfs.ReadFile(destFS, path)
+			t.Log(string(contents))
+			if err != nil {
+				t.Error(err)
+			}
+			var data interface{}
+			err = yaml.Unmarshal(contents, &data)
+			if err != nil {
+				t.Error("invalid generated yaml", err)
+			}
 		}
 		return nil
 	})

--- a/cmd/templates/terraform/variables.svc.tf
+++ b/cmd/templates/terraform/variables.svc.tf
@@ -23,7 +23,7 @@ variable "service_instance" {
   description = "proton service instance"
   type = object({
     name   = string
-    inputs = map(string)
+    inputs = any
   })
 }
 

--- a/cmd/test/main.tf
+++ b/cmd/test/main.tf
@@ -1,10 +1,10 @@
 variable "name" {
-  description = "The name of this environment"
+  description = "This should be mapped to proton metadata"
   type        = string
 }
 
 variable "environment" {
-  description = "Another environment name"
+  description = "This should be mapped to proton metadata for services"
   type        = string
 }
 
@@ -36,4 +36,9 @@ variable "public_subnet_two_cidr" {
   description = "The CIDR range for public subnet two"
   type        = string
   default     = "10.0.64.0/18"
+}
+
+variable "quote_test" {
+  description = "this variable is used to test \"quotes\" in descriptions"
+  type        = string
 }


### PR DESCRIPTION
*Issue #, if available:* #8

*Description of changes:* handle quotes in variable descriptions 

```yaml
command:
  title: command
  type: array
  items:
    type: string
  description: "(optional) command to run in the container as an array. e.g. ["sleep", "10"]. If null, does not set a command in the task definition."
```
